### PR TITLE
Add ltsv mode

### DIFF
--- a/lib/ltsview.rb
+++ b/lib/ltsview.rb
@@ -10,4 +10,5 @@ module Ltsview
   require 'json'
 
   require 'ltsview/parse'
+  require 'ltsview/hash'
 end

--- a/lib/ltsview/hash.rb
+++ b/lib/ltsview/hash.rb
@@ -1,0 +1,5 @@
+class Hash
+  def to_ltsv
+    LTSV.dump(self)
+  end
+end

--- a/lib/ltsview/parse.rb
+++ b/lib/ltsview/parse.rb
@@ -29,9 +29,12 @@ module Ltsview
        option.on('-i', '--ignore-key VAL'){ |v| @options[:ignore_key] = v.split(',') }
        option.on('-r', '--regexp key:VAL', /\A([^:]+):(.*)/){ |_, k,v| @options[:regex] = {key: k.to_sym, value: v} }
        option.on('-j', '--json') { |v| @options[:mode] = :json }
+       option.on('-l', '--ltsv') { |v| @options[:mode] = :ltsv }
        option.on('-t', '--tag VAL'){ |v| @options[:tag] = v }
        option.on('--[no-]colors'){ |v| @options[:color] = v }
        option.permute!(options)
+
+       @options[:color] = false if @options[:mode] == :ltsv
      end
 
      def file_or_stdin(&block)

--- a/spec/parse_spec.rb
+++ b/spec/parse_spec.rb
@@ -23,6 +23,16 @@ describe Ltsview::Parse do
         parse.print
       }.must_equal("{\e[35m\"hoge\"\e[0m:\e[32m\e[1;32m\"\e[0m\e[32mfuga hago\e[1;32m\"\e[0m\e[32m\e[0m,\e[35m\"foo\"\e[0m:\e[32m\e[1;32m\"\e[0m\e[32mbarbaz\e[1;32m\"\e[0m\e[32m\e[0m}\n")
     end
+
+    it 'should get non-colored ltsv' do
+      parse = Ltsview::Parse.new(['-l'])
+      capture(:stdout) {
+        $stdin = StringIO.new
+        $stdin << "hoge:fuga hago\tfoo:barbaz\n"
+        $stdin.rewind
+        parse.print
+      }.must_equal("hoge:fuga hago\tfoo:barbaz\n")
+    end
   end
 
   describe 'when appended tag' do


### PR DESCRIPTION
I added ltsv formatting mode with `-l` or `--ltsv` option. It prints lines in LTSV format, and is useful for just key filtering.

Coloring is off in this mode because coderay currently doesn't support LTSV.
