### PR TITLE
Exit with ctrl-C silently

### DIFF
--- a/bin/ltsview
+++ b/bin/ltsview
@@ -2,4 +2,6 @@
 
 require 'ltsview'
 
+trap("SIGINT") { exit }
+
 Ltsview::Parse.new(ARGV).print


### PR DESCRIPTION
Prevent error logs for interruption.
