### PR TITLE
Add `-o` and `--reorder` option to reorder keys with `--keys` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Or install it yourself as:
 
     $ cat logfile.ltsv | ltsview -k firstkey,therdkey
 
+  key select and reorder
+
+    $ cat logfile.ltsv | ltsview -k firstkey,therdkey --reorder
+
  ignore key select
 
     $ cat logfile.ltsv | ltsview -i firstkey,secondkey
@@ -69,6 +73,7 @@ Or install it yourself as:
  * `-j`, `--json` to render json format
  * `-t`, `--tag` to append tag
  * `-l`, `--ltsv`  to raw format
+ * `-o`, `--reorder` to reorder keys with `--keys` option
  * `--no-colors` to no color
 
 ## Contributing

--- a/lib/ltsview/parse.rb
+++ b/lib/ltsview/parse.rb
@@ -8,7 +8,8 @@ module Ltsview
         :file =>       nil,
         :keys =>       nil,
         :ignore_key => nil,
-        :regex =>      nil
+        :regex =>      nil,
+        :reorder =>    false
       }
       option_parse options
     end
@@ -16,7 +17,7 @@ module Ltsview
     def print
       file_or_stdin do |ltsv|
         next if ltsv.nil?
-        line = formatter(filter(ltsv))
+        line = formatter(reorder(filter(ltsv)))
         puts "#{tag}#{line}" unless line.nil?
         $stdout.flush
       end
@@ -36,6 +37,7 @@ module Ltsview
        option.on('-l', '--ltsv') { |v| @options[:mode] = :ltsv }
        option.on('-t', '--tag VAL'){ |v| @options[:tag] = v }
        option.on('--[no-]colors'){ |v| @options[:color] = v }
+       option.on('-o', '--[no-]reorder') { |v| @options[:reorder] = v }
        option.on('-v','--version'){ |v|
          puts "LTSView version: #{Ltsview::VERSION}"
          exit
@@ -72,6 +74,18 @@ module Ltsview
 
      def tag
        "@[#{@options[:tag]}] " if @options[:tag]
+     end
+
+     def reorder(ltsv)
+       if @options[:reorder] && !@options[:keys].nil?
+         @options[:keys].inject({}) do |hash, key|
+           key_sym = key.to_sym
+           hash[key_sym] = ltsv[key_sym]
+           hash
+         end
+       else
+         ltsv
+       end
      end
 
      def filter(ltsv)

--- a/spec/ltsview/parse_spec.rb
+++ b/spec/ltsview/parse_spec.rb
@@ -117,5 +117,27 @@ describe Ltsview::Parse do
 
   end
 
+  describe 'when reorder mode on' do
+    it 'should reorder key-value pairs with --keys option' do
+      parse = Ltsview::Parse.new(['--reorder', '--keys', 'foo,hoge'])
+      capture(:stdout){
+        $stdin = StringIO.new
+        $stdin << "hoge:fuga hago\tfoo:barbaz\n"
+        $stdin.rewind
+        parse.print
+      }.should eq(color("---\n:foo: barbaz\n:hoge: fuga hago\n"))
+    end
+
+    it 'should not reorder key-value pairs without --keys option' do
+      parse = Ltsview::Parse.new(['--reorder'])
+      capture(:stdout){
+        $stdin = StringIO.new
+        $stdin << "hoge:fuga hago\tfoo:barbaz\n"
+        $stdin.rewind
+        parse.print
+      }.should eq(color("---\n:hoge: fuga hago\n:foo: barbaz\n"))
+    end
+
+  end
 end
 


### PR DESCRIPTION
It reorders keys with `--keys` option like:

``` plain
$ echo "key1:val1\tkey2:val2" | ltsview -l -k key2,key1 --reorder
key2:val2   key1:val1
```

I assigned `-o` to the short option because `-r` is used for `--regexp` option, but it somehow doesn't look good to me. If you have alternatives, please tell me them.
